### PR TITLE
A few improvements to Unions

### DIFF
--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -12,6 +12,7 @@ from omegaconf import (
     FloatNode,
     IntegerNode,
     ListConfig,
+    Node,
     OmegaConf,
     StringNode,
     UnionNode,
@@ -593,12 +594,15 @@ def test_allow_objects() -> None:
         (UnionNode(element_types=[Dict[str, bool], bool]), {"foo": True}),
         (UnionNode(element_types=[Dict[str, float], float]), {"foo": 3.14}),
         (UnionNode(element_types=[bool, float], is_optional=True), None),
+        (UnionNode(element_types=[float, int]), IntegerNode(0)),
     ],
 )
 def test_valid_value_union_node(node: ValueNode, value: Any) -> None:
     expected = copy.deepcopy(value)
     node._set_value(value)
     assert node._value() == expected
+    if isinstance(expected, Node):
+        assert type(node._value()) == type(expected)
     assert isinstance(node, UnionNode)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,6 +86,9 @@ from . import Color, ConcretePlugin, IllegalType, Plugin, does_not_raise
         ),
         # ListConfig
         pytest.param(list, [1, 2, 3], ListConfig(content=[1, 2, 3]), id="ListConfig"),
+        pytest.param(
+            tuple, (1, 2, 3), ListConfig(content=(1, 2, 3)), id="ListConfig_from_tuple"
+        ),
     ],
 )
 def test_node_wrap(target_type: Any, value: Any, expected: Any) -> None:


### PR DESCRIPTION
* Fix assignment of a ValueNode to a UnionNode, which could sometimes
  results in an incorrect type
* Remove the `use_type` argument to simplify the code
* Keep the wrapping of a `Node` instance in `_maybe_wrap()` limited to
  Unions, to reduce the risk of unintended side effects